### PR TITLE
fix obsolate "fi" at the end of post-start script

### DIFF
--- a/templates/default/upstart/docker.conf.erb
+++ b/templates/default/upstart/docker.conf.erb
@@ -70,5 +70,4 @@ post-start script
     done
 
     echo "Docker is up"
-  fi
 end script


### PR DESCRIPTION
Found upstart service to fail on start due an lost "fi" from the "if" statement at the end of the script.
